### PR TITLE
Fixed COCO API link

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pip3 install -r requirements.txt
 ```
 Additionaly, to use ``demo.pynb``, you will also need [coco python api](https://github.com/cocodataset/cocoapi). You can get this using
 ```
-pip3 install git+https://github.com/philferriere/cocoapi.git
+pip3 install git+https://github.com/philferriere/cocoapi.git#subdirectory=PythonAPI
 ```
 
 ### Download


### PR DESCRIPTION
Pip installation for COCO Python API changed. See most recent here: https://github.com/philferriere/cocoapi